### PR TITLE
Fix cross language tests at least on macOS

### DIFF
--- a/cross-language-tests/run_tests.py
+++ b/cross-language-tests/run_tests.py
@@ -89,7 +89,7 @@ def run_java_roundtrip(
 
     # Add library path if blosc is found
     if blosc_path:
-        cmd.append(f"-Djava.library.path={blosc_path}")
+        cmd.append(f"-Djna.library.path={blosc_path}")
 
     cmd.extend(
         [

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,30 @@
                             <argLine>-Xmx4g -Djna.library.path=/opt/homebrew/opt/c-blosc/lib</argLine>
                         </configuration>
                     </plugin>
+
+					<plugin>
+						<artifactId>maven-assembly-plugin</artifactId>
+						<configuration>
+							<archive>
+								<manifest>
+									<mainClass>org.mastodon.geff.RoundTripGeff</mainClass>
+								</manifest>
+							</archive>
+							<descriptorRefs>
+								<descriptorRef>jar-with-dependencies</descriptorRef>
+							</descriptorRefs>
+						</configuration>
+						<executions>
+							<execution>
+								<id>make-assembly</id>
+								<phase>package</phase>
+								<goals>
+									<goal>single</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+                    
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
Two issues prevented the Python/Java round-trip tests from running at all.

### `mvn package` produced no runnable jar

The `pom.xml` had no `maven-assembly-plugin`, so `mvn package` only wrote compiled classes to `target/classes/` with no dependency JARs alongside them. The test runner looks for a `*-jar-with-dependencies.jar`
first; without it, it fell back to `target/classes/` alone, leaving n5, n5-zarr, imglib2 and friends off the classpath. Every test failed immediately with `NoClassDefFoundError: org/janelia/saalfeldlab/n5/N5Reader`.

Fix: add `maven-assembly-plugin` to the `build` profile so `mvn package` also produces `target/geff-*-jar-with-dependencies.jar`.

### Blosc native library was never found

JNA (used by `n5-blosc` to load `libblosc`) ignores `-Djava.library.path` and uses its own `-Djna.library.path` property instead. The test runner was passing the wrong property, so even with c-blosc correctly installed
via Homebrew, JNA could not locate `libblosc.dylib` and every run crashed with `UnsatisfiedLinkError`.

Fix: pass `-Djna.library.path` in `run_tests.py`, consistent with how the Maven Surefire config already does it in `pom.xml`.


Done with the help of Claude Sonnet to make sense of the error, and @tpietzsch 
